### PR TITLE
Remove entrypoint from recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "0.4.0rc3" %}
-{% set build_number = "1" %}
+{% set build_number = "2" %}
 
 package:
   name: tensorboard
@@ -14,8 +14,6 @@ build:
   # noarch: python
 
   number: {{ build_number }}
-  entry_points:
-    - tensorboard = tensorboard.main:main
   script:
     - pip install --no-deps tensorflow-tensorboard=={{ version }}
 


### PR DESCRIPTION
Since we install from wheel, let the wheel define it properly.

If we ever build from source, we will need to emulate the one in the wheel (which checks if we are in windows or not to select a proper command).

I'm merging this as soon as we get the green tick.