### PR TITLE
Upgrade to 2.0.2 and update requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.15.0" %}
+{% set version = "2.0.2" %}
 {% set build_number = 0 %}
 
 package:
@@ -7,9 +7,9 @@ package:
 
 source:
   url: https://pypi.io/packages/py2/t/tensorboard/tensorboard-{{ version }}-py2-none-any.whl  # [py2k]
-  sha256: 612b789386aa1b2c4804e1961273b37f8e4dd97613f98bc90ff0402d24627f50  # [py2k]
+  sha256: 32d9dec38d053d7d75796eb7c2e0d77285af35f69ee1a6796ab5ecc896679fb3  # [py2k]
   url: https://pypi.io/packages/py3/t/tensorboard/tensorboard-{{ version }}-py3-none-any.whl  # [py3k]
-  sha256: 4cad2c65f6011e51609b463014c014fd7c6ddd9c1263af1d4f18dd97ed88c2bc  # [py3k]
+  sha256: ccae56f01acc78a138474081b631af52017c2075ffe1c453d58c49d5046ef081  # [py3k]
 
 build:
   number: {{ build_number }}
@@ -29,11 +29,14 @@ requirements:
     - wheel >=0.26
     - numpy >=1.12.0
     - six >=1.10.0
-    - protobuf >=3.4.0
-    - werkzeug >=0.11.10
+    - protobuf >=3.6.0
+    - werkzeug >=0.11.15
     - markdown >=2.6.8
     - absl-py >=0.8.0
-    - grpcio >=1.6.3
+    - grpcio >=1.24.3
+    - google-auth >=1.6.3
+    - google-auth-oauthlib >=0.4.1
+    - requests >=2.21.0
     - futures >=3.1.1   # [py27]
 
 test:


### PR DESCRIPTION
This will fail unfortunately because grpcio >=1.24.3 is not yet
available on conda-forge.

Depends on https://github.com/conda-forge/grpcio-feedstock/pull/14

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
