### PR TITLE
tensorboard v2.2.1, update dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tensorboard" %}
-{% set version = "2.1.1" %}
+{% set version = "2.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/py3/t/tensorboard/tensorboard-{{ version }}-py3-none-any.whl
-  sha256: 3a36da59d4e13fb140d04636aaf544f1a38364a7e3609a15cdaf01a5d3073b37
+  sha256: 9a2a2dc9856187679e93f3c95e5dc771dd47e3257db09767b4be118d734b4dc2
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script:
     - python -m pip install --no-deps --ignore-installed ./tensorboard-{{ version }}-py3-none-any.whl
@@ -21,6 +21,7 @@ requirements:
   host:
     - python >=3.2
     - pip
+    - setuptools >=41.0.0
   run:
     - python >=3.2
     - wheel >=0.26
@@ -31,7 +32,10 @@ requirements:
     - markdown >=2.6.8
     - absl-py >=0.4
     - grpcio >=1.24.3
-    - google-auth-oauthlib ==0.4.1
+    - google-auth >=1.6.3,<2
+    - google-auth-oauthlib >=0.4.1,<0.5
+    - requests >=2.21.0,<3
+    - tensorboard-plugin-wit >=1.6.0
 
 test:
   imports:


### PR DESCRIPTION
Doesn't work yet because the new dependency tensorboard-plugin-wit is missing from conda-forge.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->