### PR TITLE
Strip pip install-provenance from dist-info; add version/installer tests

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,3 +2,8 @@ set -ex
 python -m pip install --no-deps --ignore-installed ./tensorboard-${PKG_VERSION}-py3-none-any.whl
 # Remove the strict protobuf requirement. Conda will manage it.
 sed -i 's/^Requires-Dist: protobuf.*/Requires-Dist: protobuf/' ${SP_DIR}/tensorboard-${PKG_VERSION}.dist-info/METADATA
+# Drop pip's install-provenance files so the dist-info reflects a clean conda
+# install (conda rewrites INSTALLER to "conda"; these would otherwise still
+# advertise a pip/local-wheel install).
+rm -f ${SP_DIR}/tensorboard-${PKG_VERSION}.dist-info/direct_url.json \
+      ${SP_DIR}/tensorboard-${PKG_VERSION}.dist-info/REQUESTED

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6
 
 build:
-  number: 0
+  number: 1
   noarch: python
   python:
     entry_points:
@@ -48,6 +48,12 @@ tests:
     script:
       - tensorboard -h
       - pip check
+      # Guard against version-mismatch regressions: the package must report ${{ version }}
+      - tensorboard --version_tb
+      - python -c "import tensorboard.version as v; print('tensorboard.version.VERSION =', v.VERSION); assert v.VERSION == '${{ version }}', v.VERSION"
+      - python -c "from importlib.metadata import version; print('importlib.metadata version =', version('tensorboard')); assert version('tensorboard') == '${{ version }}', version('tensorboard')"
+      # Guard that the package advertises a conda install, not pip/pypi
+      - python -c "from importlib.metadata import distribution as d; t = (d('tensorboard').read_text('INSTALLER') or '').strip(); print('INSTALLER =', repr(t)); assert t == 'conda', t"
 
 about:
   license: Apache-2.0

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -48,6 +48,7 @@ tests:
     script:
       - tensorboard -h
       - pip check
+      - pip list | grep tensorboard
       # Guard against version-mismatch regressions: the package must report ${{ version }}
       - tensorboard --version_tb
       - python -c "import tensorboard.version as v; print('tensorboard.version.VERSION =', v.VERSION); assert v.VERSION == '${{ version }}', v.VERSION"


### PR DESCRIPTION
Tensorboard was reporting 2.19 for me. So i asked AI to investigate. 

seems like it makes sense to me.

<details><summary>Claude's draft</summary>

The wheel-based recipe `pip install`s the upstream tensorboard wheel, which leaves `direct_url.json` and `REQUESTED` in the dist-info. These advertise a pip/local-wheel install even though conda rewrites `INSTALLER` to "conda". Remove them in build.sh so the installed package's dist-info consistently reflects a clean conda install.

Also add regression guards to the test stage:
- `tensorboard --version_tb` / `tensorboard.version.VERSION` / `importlib.metadata.version` must all equal the recipe version.
- `INSTALLER` must be "conda".

Bump build number 0 -> 1 (same source, packaging change only).

Verified with a local `build-locally.py` run: package builds, all tests pass, and the resulting `.conda` has no `direct_url.json`/`REQUESTED` and `INSTALLER=conda`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume 2e3f17ef-644d-4081-8e38-a882e00dcba0
```
</details>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
